### PR TITLE
content/2024/summer-teaching-plans: Add summer 2024 teaching plans post

### DIFF
--- a/content/2024/summer-teaching-plans.rst
+++ b/content/2024/summer-teaching-plans.rst
@@ -1,0 +1,83 @@
+:blogpost: true
+:date: 2024-02-14
+:author: Richard Darst
+:category: teaching
+
+
+2024 summer teaching plans
+==========================
+
+It may seem a long time ago,  but summer is approaching.  That means
+it's time to start announcing our summer teaching activities.  This is
+the 2024 implementation of our :doc:`yearly kickstart and onboarding
+strategy </2023/kickstart>`
+
+"Kickstart" means it's a first look and practical steps to get started
+quickly, but not the most advanced course.
+
+
+
+Summer plan
+-----------
+
+The course page: :external:doc:`training/scip/kickstart-2024`
+
+Each June, we have a training program designed around the schedule of
+new summer research interns.
+
+* (Monday reserved for local department activities)
+* **Day 1: Tue, 4 Mar**: A very broad introduction to scientific
+  computing and how to organizing your research
+* **Day 2: Tue, 5 Mar**: How to use the computing cluster: basics
+* **Day 3: Tue, 6 Mar**: Continuation of day 2, but more advanced and
+  getting to parallelism and running many things at once
+* (Friday can be used by specialized tutorials and follow-ups with
+  specific tools)
+
+Each day is approximately 12:00-16:00, online (livestream), with
+videos available by the same evening.  It's completely OK to come the
+only days you can, for example only the first day for those who aren't
+using the computer cluster, or skipping the last day and coming back
+to it once you need those tools.
+
+
+
+What you should do
+------------------
+
+* If you are a new researcher: definitely register and reserve the
+  dates.  Attend until it starts to feel unnecessary for you.
+* Department HR and coordinators: add this to the information you give
+  to new researchers.  If you department is computationally oriented,
+  try to integrate this into your schedule.
+* If you are not at Aalto but think this is relevant to you or the
+  people you support, send them to our course and/or contribute.
+
+  * We've designed this course so that it's also suitable as an
+    introduction at other locations - most universities in Finland
+    send their students here (online).  Wherever you are, you could
+    send your students as well.  We also welcome co-teachers.
+
+  * We have :external:doc:`info on what your cluster needs to have to
+    follow along <triton/tut/required-cluster-setup>`, but we are open
+    to ideas to make it more reusable.
+
+  * Our "lecture/demo, then exercise" format is suitable for you to
+    help your local audience during the exercises to fill in what's
+    different for you.
+
+
+
+Other teaching
+--------------
+
+The "Kickstart" course is one of our capstones.  There is also:
+
+* `CodeRefinery March 12-14 and 19-21
+  <https://coderefinery.github.io/2024-03-12-workshop/>`__, which you
+  could say is more basic handling code for scientists (not a
+  prerequisite).
+* The more advanced :external:doc:`workflows course
+  <training/scip/workflows-2024>` which is more advanced, but
+  different: it's designed to show full examples of how the cluster is
+  actually used, not be a tutorial of the individual pieces.


### PR DESCRIPTION
- An introduction to what we'll do in the summer.  Suitable for
  sending to departments or for people to know what it's all about.
- Review: worth a detailed read
